### PR TITLE
added websocket test case

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ type Websocket struct {
 
 #### Receive message
 
-A Websocket message will be expected from your server depending on how it's configured the `Receive` property on the `WebsocketTestCase`. If your endpoint sends a different message, the `Test` function will return an `error`. `Message` has different fields to be configured, see them below:
+A Websocket message can be configured to be received by your Websocket server using the `Receive` property on the `WebsocketTestCase`. The `Receive` property is optional. If your endpoint sends a different message, the `Test` function will return an `error`. `Message` has different fields to be configured, see them below:
 
 ```go
 // Message is used to validate if a Websocket message

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ type Websocket struct {
 
 #### Receive message
 
-A Websocket message can be configured to be received by your Websocket server using the `Receive` property on the `WebsocketTestCase`. The `Receive` property is optional. If your endpoint sends a different message, the `Test` function will return an `error`. `Message` has different fields to be configured, see them below:
+A Websocket message can be expected by your Websocket server using the `Receive` property on the `WebsocketTestCase`. The `Receive` property is optional. If your endpoint sends a different message, the `Test` function will return an `error`. `Message` has different fields to be configured, see them below:
 
 ```go
 // Message is used to validate if a Websocket message

--- a/README.md
+++ b/README.md
@@ -261,6 +261,41 @@ You can also ignore request body field assertion adding the annotation `<<PRESEN
 
 Reference: https://github.com/kinbiko/jsonassert
 
+#### Connection
+
+In case you want to reuse the Websocket connection of a test case, you can call the `.Connection()` function to get the connection. See below how to do it:
+
+```go
+initialTestCase := &WebsocketTestCase{
+	Description: "First test case with a new connection"
+	Call: call.Message{
+		Scheme:  call.WebsocketSchemeWS,
+		URL:     "localhost:8080",
+		Path:    "/handler",
+	},
+}
+
+err := Test(initialTestCase)
+if err != nil {
+	t.Fatal(err)
+}
+
+// Get the connection established in the first test case
+conn := initialTestCase.Connection()
+
+// Use the connection in a second test case
+err = Test(&WebsocketTestCase{
+	Description: "Second test case with the same connection",
+	Call: call.Message{
+		Connection: conn,
+		Message:    `{}`,
+	},
+})
+if err != nil {
+	t.Fatal(err)
+}
+```
+
 ### Assertions
 
 There are few different assertion that can be made. Assertions work for `SQL` and `HTTP`.

--- a/call/websocket.go
+++ b/call/websocket.go
@@ -1,0 +1,44 @@
+package call
+
+import (
+	"net/http"
+
+	"github.com/gorilla/websocket"
+)
+
+type WebsocketScheme string
+
+const (
+	WebsocketSchemeWS  WebsocketScheme = "ws"
+	WebsocketSchemeWSS WebsocketScheme = "wss"
+)
+
+// Message sets up how a Websocket message will be sent
+type Message struct {
+	// URL that will be used to connect to the Websocket server.
+	// eg: my-websocket-server:8080
+	URL string
+
+	// Path that will be used to connect to the Websocket server.
+	// eg: /websocket
+	Path string
+
+	// Scheme that will be used to connect to the Websocket server.
+	// if nothing is set, the default will be `ws`.
+	// eg: ws or wss
+	Scheme WebsocketScheme
+
+	// Header will be used to connect to the Websocket server.
+	// eg: content-type=application/json
+	Header http.Header
+
+	// Connection is the Websocket connection that will be used to make the calls (this field is optional).
+	// If you want to reuse a connection, you can set it here.
+	// If you set a connection, the `URL`, `Path`, `Header` and `Scheme` will be ignored.
+	Connection *websocket.Conn
+
+	// Message that will be sent with the request.
+	// a multiline string is valid.
+	// eg: { "foo": "bar" }
+	Message string
+}

--- a/call/websocket.go
+++ b/call/websocket.go
@@ -14,7 +14,7 @@ const (
 )
 
 // Message sets up how a Websocket message will be sent
-type Message struct {
+type Websocket struct {
 	// URL that will be used to connect to the Websocket server.
 	// eg: my-websocket-server:8080
 	URL string

--- a/expect/websocket.go
+++ b/expect/websocket.go
@@ -1,0 +1,14 @@
+package expect
+
+import "time"
+
+// Message is used to validate if a Websocket message
+type Message struct {
+	// Content expected in the Websocket message.
+	// A multiline string is valid.
+	// eg: { "foo": "bar" }
+	Content string
+
+	// Timeout is the time to wait for a message to be received.
+	Timeout time.Duration
+}

--- a/expect/websocket.go
+++ b/expect/websocket.go
@@ -2,7 +2,7 @@ package expect
 
 import "time"
 
-// Message is used to validate if a Websocket message
+// Message is used to validate if a Websocket message is correct
 type Message struct {
 	// Content expected in the Websocket message.
 	// A multiline string is valid.

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	golang.org/x/text v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jarcoal/httpmock v1.2.0 h1:gSvTxxFR/MEMfsGrvRbdfpRUMBStovlSRLw0Ep1bwwc=
 github.com/jarcoal/httpmock v1.2.0/go.mod h1:oCoTsnAz4+UoOUIf5lJOWV2QQIW5UoeUI6aM2YnWAZk=
 github.com/kinbiko/jsonassert v1.1.1 h1:DB12divY+YB+cVpHULLuKePSi6+ui4M/shHSzJISkSE=

--- a/grpc.go
+++ b/grpc.go
@@ -80,7 +80,7 @@ func (t *GRPCTestCase) assert(resp []reflect.Value) error {
 	je := utils.JsonError{}
 	jsonassert.New(&je).Assertf(string(respValueJSON), string(expectedValueJSON))
 	if je.Err != nil {
-		return errors.Errorf(" body does not match: %v", je.Err.Error())
+		return errors.Errorf("body does not match: %v", je.Err.Error())
 	}
 
 	if respErr == nil && t.Output.Err == nil {

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	errMessage = "ERROR"
-	port       = 9000
+	grpcPort   = 9000
 )
 
 type Server struct {
@@ -46,7 +46,7 @@ func (s *Server) SayHello(ctx context.Context, in *chat.Message) (*chat.Message,
 }
 
 func init() {
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", grpcPort))
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestGRPC_NilClient(t *testing.T) {
 
 func client() (chat.ChatServiceClient, error) {
 	var conn *grpc.ClientConn
-	conn, err := grpc.Dial(fmt.Sprintf(":%d", port), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.Dial(fmt.Sprintf(":%d", grpcPort), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err
 	}

--- a/websocket.go
+++ b/websocket.go
@@ -1,0 +1,154 @@
+package integration
+
+import (
+	"bytes"
+	"io"
+	"net/url"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/jarcoal/httpmock"
+	"github.com/kinbiko/jsonassert"
+	"github.com/lucasvmiguel/integration/assertion"
+	"github.com/lucasvmiguel/integration/call"
+	"github.com/lucasvmiguel/integration/expect"
+	"github.com/lucasvmiguel/integration/internal/utils"
+	"github.com/pkg/errors"
+)
+
+// WebsocketTestCase describes a Websocket test case that will run
+type WebsocketTestCase struct {
+	// Description describes a test case
+	// It can be really useful to understand which tests are breaking
+	Description string
+
+	// Call is the Websocket server the test case will try to connect and send a message
+	Call call.Message
+
+	// Message is going to be used to assert if the Websocket server message returned what was expected.
+	Message expect.Message
+
+	// Assertions that will run in test case
+	Assertions []assertion.Assertion
+}
+
+// Test runs an Websocket test case
+func (t *WebsocketTestCase) Test() error {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	for _, assertion := range t.Assertions {
+		err := assertion.Setup()
+		if err != nil {
+			return errors.New(errString(err, t.Description, "failed to setup assertion"))
+		}
+	}
+
+	if t.Call.Connection == nil {
+		conn, err := t.connect()
+		if err != nil {
+			return errors.New(errString(err, t.Description, "failed to connect Websocket endpoint"))
+		}
+		t.Call.Connection = conn
+	}
+
+	resp, err := t.listenAndCall(t.Call.Connection)
+	if err != nil {
+		return errors.New(errString(err, t.Description, "failed to call and/or listen the Websocket server"))
+	}
+
+	err = t.assert(resp)
+	if err != nil {
+		return errors.New(errString(err, t.Description, "failed to assert Websocket response"))
+	}
+
+	for _, assertion := range t.Assertions {
+		err := assertion.Assert()
+		if err != nil {
+			return errors.New(errString(err, t.Description, "failed to assert"))
+		}
+	}
+
+	return nil
+}
+
+func (t *WebsocketTestCase) assert(message []byte) error {
+	content, err := io.ReadAll(bytes.NewBuffer(message))
+	if err != nil {
+		return errors.Wrap(err, "failed to read message content")
+	}
+
+	contentString := string(content)
+
+	if utils.IsJSON(t.Message.Content) {
+		je := utils.JsonError{}
+		jsonassert.New(&je).Assertf(contentString, t.Message.Content)
+		if je.Err != nil {
+			return errors.Errorf("content is a JSON. content does not match: %v", je.Err.Error())
+		}
+	} else {
+		if contentString != t.Message.Content {
+			return errors.Errorf("content is a regular string. content should be '%s' it got '%s'", t.Message.Content, contentString)
+		}
+	}
+
+	return nil
+}
+
+func (t *WebsocketTestCase) connect() (*websocket.Conn, error) {
+	if t.Call.Scheme == "" {
+		t.Call.Scheme = call.WebsocketSchemeWS
+	}
+
+	u := url.URL{Scheme: string(t.Call.Scheme), Host: t.Call.URL, Path: t.Call.Path}
+
+	conn, _, err := websocket.DefaultDialer.Dial(u.String(), t.Call.Header)
+	if err != nil {
+		return nil, errors.Errorf("error to connect to the Websocket server: %s", err.Error())
+	}
+
+	return conn, nil
+}
+
+func (t *WebsocketTestCase) call(conn *websocket.Conn) error {
+	err := conn.WriteMessage(websocket.TextMessage, []byte(t.Call.Message))
+	if err != nil {
+		return errors.Errorf("error to send message to the Websocket server: %s", err.Error())
+	}
+
+	return nil
+}
+
+func (t *WebsocketTestCase) listenAndCall(conn *websocket.Conn) ([]byte, error) {
+	messageChan := make(chan []byte)
+	timeout := t.Message.Timeout
+	if timeout == 0 {
+		timeout = 5 * time.Second
+	}
+
+	go func() {
+		for {
+			_, m, err := conn.ReadMessage()
+			if err != nil {
+				break
+			}
+
+			if m != nil {
+				messageChan <- m
+				break
+			}
+		}
+	}()
+
+	err := t.call(conn)
+	if err != nil {
+		return nil, errors.Errorf("error to send message to the Websocket server: %s", err.Error())
+	}
+
+	select {
+	case message := <-messageChan:
+		return message, nil
+	case <-time.After(timeout):
+		return nil, errors.Errorf("timeout to read message from the Websocket server")
+	}
+}

--- a/websocket.go
+++ b/websocket.go
@@ -23,10 +23,10 @@ type WebsocketTestCase struct {
 	Description string
 
 	// Call is the Websocket server the test case will try to connect and send a message
-	Call call.Message
+	Call call.Websocket
 
-	// Message is going to be used to assert if the Websocket server message returned what was expected.
-	Message expect.Message
+	// Receive is going to be used to assert if the Websocket server message returned what was expected.
+	Receive expect.Message
 
 	// Assertions that will run in test case
 	Assertions []assertion.Assertion
@@ -85,15 +85,15 @@ func (t *WebsocketTestCase) assert(message []byte) error {
 
 	contentString := string(content)
 
-	if utils.IsJSON(t.Message.Content) {
+	if utils.IsJSON(t.Receive.Content) {
 		je := utils.JsonError{}
-		jsonassert.New(&je).Assertf(contentString, t.Message.Content)
+		jsonassert.New(&je).Assertf(contentString, t.Receive.Content)
 		if je.Err != nil {
 			return errors.Errorf("content is a JSON. content does not match: %v", je.Err.Error())
 		}
 	} else {
-		if contentString != t.Message.Content {
-			return errors.Errorf("content is a regular string. content should be '%s' it got '%s'", t.Message.Content, contentString)
+		if contentString != t.Receive.Content {
+			return errors.Errorf("content is a regular string. content should be '%s' it got '%s'", t.Receive.Content, contentString)
 		}
 	}
 
@@ -126,7 +126,7 @@ func (t *WebsocketTestCase) call(conn *websocket.Conn) error {
 
 func (t *WebsocketTestCase) listenAndCall(conn *websocket.Conn) ([]byte, error) {
 	messageChan := make(chan []byte)
-	timeout := t.Message.Timeout
+	timeout := t.Receive.Timeout
 	if timeout == 0 {
 		timeout = 5 * time.Second
 	}

--- a/websocket.go
+++ b/websocket.go
@@ -26,6 +26,7 @@ type WebsocketTestCase struct {
 	Call call.Websocket
 
 	// Receive is going to be used to assert if the Websocket server message returned what was expected.
+	// This field is optional as a Websocket server can never send a message to the client.
 	Receive expect.Message
 
 	// Assertions that will run in test case

--- a/websocket.go
+++ b/websocket.go
@@ -72,6 +72,11 @@ func (t *WebsocketTestCase) Test() error {
 	return nil
 }
 
+// Connection returns the Websocket connection
+func (t *WebsocketTestCase) Connection() *websocket.Conn {
+	return t.Call.Connection
+}
+
 func (t *WebsocketTestCase) assert(message []byte) error {
 	content, err := io.ReadAll(bytes.NewBuffer(message))
 	if err != nil {
@@ -104,7 +109,7 @@ func (t *WebsocketTestCase) connect() (*websocket.Conn, error) {
 
 	conn, _, err := websocket.DefaultDialer.Dial(u.String(), t.Call.Header)
 	if err != nil {
-		return nil, errors.Errorf("error to connect to the Websocket server: %s", err.Error())
+		return nil, errors.Errorf("error to connect to the Websocket server (%s): %s", u.String(), err.Error())
 	}
 
 	return conn, nil

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -1,0 +1,306 @@
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/lucasvmiguel/integration/assertion"
+	"github.com/lucasvmiguel/integration/call"
+	"github.com/lucasvmiguel/integration/expect"
+)
+
+var upgrader = websocket.Upgrader{}
+
+func jsonHandler(w http.ResponseWriter, req *http.Request) {
+	c, err := upgrader.Upgrade(w, req, nil)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer c.Close()
+
+	for {
+		mt, messageReceived, err := c.ReadMessage()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			break
+		}
+
+		if messageReceived != nil {
+			body := struct {
+				Title  string `json:"title"`
+				UserID int    `json:"userId"`
+			}{}
+			err := json.NewDecoder(bytes.NewBuffer(messageReceived)).Decode(&body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				break
+			}
+
+			messageSent := []byte(`{
+			"title": "some title",
+			"description": "some description",
+			"userId": 1,
+			"comments": [
+				{ "id": 1, "text": "foo" },
+				{ "id": 2, "text": "bar" }
+			]
+		}`)
+
+			_, err = http.Get("https://jsonplaceholder.typicode.com/posts/1")
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				break
+			}
+
+			err = c.WriteMessage(mt, messageSent)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+			break
+		}
+	}
+}
+
+func stringHandler(w http.ResponseWriter, req *http.Request) {
+	if req.Header.Get("foo") != "bar" {
+		http.Error(w, "invalid header", http.StatusInternalServerError)
+		return
+	}
+
+	c, err := upgrader.Upgrade(w, req, nil)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer c.Close()
+
+	for {
+		mt, messageReceived, err := c.ReadMessage()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			break
+		}
+
+		if messageReceived != nil {
+			body := struct {
+				Title  string `json:"title"`
+				UserID int    `json:"userId"`
+			}{}
+			err := json.NewDecoder(bytes.NewBuffer(messageReceived)).Decode(&body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				break
+			}
+
+			messageSent := `
+			foo
+			 bar`
+
+			err = c.WriteMessage(mt, []byte(messageSent))
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+			break
+		}
+	}
+}
+
+func init() {
+	http.HandleFunc("/handler-json", jsonHandler)
+	http.HandleFunc("/handler-string", stringHandler)
+
+	go http.ListenAndServe(":8090", nil)
+}
+
+func TestWebsocket_SuccessJSON(t *testing.T) {
+	err := Test(&WebsocketTestCase{
+		Description: "TestWebsocket_Success",
+		Call: call.Message{
+			Scheme: call.WebsocketSchemeWS,
+			URL:    fmt.Sprintf("localhost:%d", 8090),
+			Path:   "/handler-json",
+			Message: `{
+				"title": "some title",
+				"userId": 1
+			}`,
+		},
+		Message: expect.Message{
+			Content: `{
+				"title": "some title",
+				"description": "<<PRESENCE>>",
+				"userId": 1,
+				"comments": [
+					{ "id": 1, "text": "foo" },
+					{ "id": 2, "text": "bar" }
+				]
+			}`,
+		},
+		Assertions: []assertion.Assertion{
+			&assertion.HTTP{
+				Request: expect.Request{
+					URL:    "https://jsonplaceholder.typicode.com/posts/1",
+					Method: http.MethodGet,
+				},
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWebsocket_SuccessWithConnectionAlreadyCreated(t *testing.T) {
+	u := url.URL{Scheme: "ws", Host: "localhost:8090", Path: "/handler-json"}
+
+	conn, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = Test(&WebsocketTestCase{
+		Description: "TestWebsocket_Success",
+
+		Call: call.Message{
+			Connection: conn,
+			Scheme:     call.WebsocketSchemeWSS,
+			URL:        "ignored",
+			Message: `{
+				"title": "some title",
+				"userId": 1
+			}`,
+		},
+		Message: expect.Message{
+			Content: `{
+				"title": "some title",
+				"description": "<<PRESENCE>>",
+				"userId": 1,
+				"comments": [
+					{ "id": 1, "text": "foo" },
+					{ "id": 2, "text": "bar" }
+				]
+			}`,
+		},
+		Assertions: []assertion.Assertion{
+			&assertion.HTTP{
+				Request: expect.Request{
+					URL:    "https://jsonplaceholder.typicode.com/posts/1",
+					Method: http.MethodGet,
+				},
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWebsocket_SuccessString(t *testing.T) {
+	err := Test(&WebsocketTestCase{
+		Description: "TestWebsocket_Success",
+		Call: call.Message{
+			Scheme: call.WebsocketSchemeWS,
+			URL:    fmt.Sprintf("localhost:%d", 8090),
+			Path:   "/handler-string",
+			Header: http.Header{
+				"foo": []string{"bar"},
+			},
+			Message: `{
+				"title": "some title",
+				"userId": 1
+			}`,
+		},
+		Message: expect.Message{
+			Content: `
+			foo
+			 bar`,
+		},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWebsocket_InvalidURL(t *testing.T) {
+	err := Test(&WebsocketTestCase{
+		Description: "TestWebsocket_InvalidPath",
+		Call: call.Message{
+			Scheme: call.WebsocketSchemeWS,
+			URL:    fmt.Sprintf("invalid:%d", 8090),
+			Path:   "/handler-json",
+			Message: `{
+				"title": "some title",
+				"userId": 1
+			}`,
+		},
+		Message: expect.Message{
+			Content: `{
+				"title": "some title",
+				"description": "<<PRESENCE>>",
+				"userId": 1,
+				"comments": [
+					{ "id": 1, "text": "foo" },
+					{ "id": 2, "text": "bar" }
+				]
+			}`,
+		},
+		Assertions: []assertion.Assertion{
+			&assertion.HTTP{
+				Request: expect.Request{
+					URL:    "https://jsonplaceholder.typicode.com/posts/1",
+					Method: http.MethodGet,
+				},
+			},
+		},
+	})
+
+	if err == nil {
+		t.Fatal("it should return an error due to an invalid method")
+	}
+}
+
+func TestWebsocket_InvalidPath(t *testing.T) {
+	err := Test(&WebsocketTestCase{
+		Description: "TestWebsocket_InvalidPath",
+		Call: call.Message{
+			Scheme: call.WebsocketSchemeWS,
+			URL:    fmt.Sprintf("localhost:%d", 8090),
+			Path:   "/invalid",
+			Message: `{
+				"title": "some title",
+				"userId": 1
+			}`,
+		},
+		Message: expect.Message{
+			Content: `{
+				"title": "some title",
+				"description": "<<PRESENCE>>",
+				"userId": 1,
+				"comments": [
+					{ "id": 1, "text": "foo" },
+					{ "id": 2, "text": "bar" }
+				]
+			}`,
+		},
+		Assertions: []assertion.Assertion{
+			&assertion.HTTP{
+				Request: expect.Request{
+					URL:    "https://jsonplaceholder.typicode.com/posts/1",
+					Method: http.MethodGet,
+				},
+			},
+		},
+	})
+
+	if err == nil {
+		t.Fatal("it should return an error due to an invalid method")
+	}
+}

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -150,7 +150,7 @@ func init() {
 func TestWebsocket_SuccessJSON(t *testing.T) {
 	err := Test(&WebsocketTestCase{
 		Description: "TestWebsocket_SuccessJSON",
-		Call: call.Message{
+		Call: call.Websocket{
 			Scheme: call.WebsocketSchemeWS,
 			URL:    fmt.Sprintf("localhost:%d", 8090),
 			Path:   "/handler-json",
@@ -159,7 +159,7 @@ func TestWebsocket_SuccessJSON(t *testing.T) {
 				"userId": 1
 			}`,
 		},
-		Message: expect.Message{
+		Receive: expect.Message{
 			Content: `{
 				"title": "some title",
 				"description": "<<PRESENCE>>",
@@ -195,8 +195,7 @@ func TestWebsocket_SuccessWithConnectionAlreadyCreated(t *testing.T) {
 
 	err = Test(&WebsocketTestCase{
 		Description: "TestWebsocket_SuccessWithConnectionAlreadyCreated",
-
-		Call: call.Message{
+		Call: call.Websocket{
 			Connection: conn,
 			Scheme:     call.WebsocketSchemeWSS,
 			URL:        "ignored",
@@ -205,7 +204,7 @@ func TestWebsocket_SuccessWithConnectionAlreadyCreated(t *testing.T) {
 				"userId": 1
 			}`,
 		},
-		Message: expect.Message{
+		Receive: expect.Message{
 			Content: `{
 				"title": "some title",
 				"description": "<<PRESENCE>>",
@@ -234,7 +233,7 @@ func TestWebsocket_SuccessWithConnectionAlreadyCreated(t *testing.T) {
 func TestWebsocket_EmptyMessage(t *testing.T) {
 	err := Test(&WebsocketTestCase{
 		Description: "TestWebsocket_EmptyMessage",
-		Call: call.Message{
+		Call: call.Websocket{
 			Scheme: call.WebsocketSchemeWS,
 			URL:    fmt.Sprintf("localhost:%d", 8090),
 			Path:   "/infinite-handler",
@@ -249,7 +248,7 @@ func TestWebsocket_EmptyMessage(t *testing.T) {
 func TestWebsocket_EmptyReturn(t *testing.T) {
 	err := Test(&WebsocketTestCase{
 		Description: "TestWebsocket_EmptyReturn",
-		Call: call.Message{
+		Call: call.Websocket{
 			Scheme:  call.WebsocketSchemeWS,
 			URL:     fmt.Sprintf("localhost:%d", 8090),
 			Path:    "/infinite-handler",
@@ -265,7 +264,7 @@ func TestWebsocket_EmptyReturn(t *testing.T) {
 func TestWebsocket_SuccessWithConnectionWithReturnedConnection(t *testing.T) {
 	initialTestCase := &WebsocketTestCase{
 		Description: "TestWebsocket_SuccessWithConnectionWithReturnedConnection_1",
-		Call: call.Message{
+		Call: call.Websocket{
 			Scheme:  call.WebsocketSchemeWS,
 			URL:     fmt.Sprintf("localhost:%d", 8090),
 			Path:    "/infinite-handler",
@@ -282,7 +281,7 @@ func TestWebsocket_SuccessWithConnectionWithReturnedConnection(t *testing.T) {
 
 	err = Test(&WebsocketTestCase{
 		Description: "TestWebsocket_SuccessWithConnectionWithReturnedConnection_2",
-		Call: call.Message{
+		Call: call.Websocket{
 			Connection: conn,
 			Scheme:     call.WebsocketSchemeWSS,
 			URL:        "ignored",
@@ -297,7 +296,7 @@ func TestWebsocket_SuccessWithConnectionWithReturnedConnection(t *testing.T) {
 func TestWebsocket_SuccessString(t *testing.T) {
 	err := Test(&WebsocketTestCase{
 		Description: "TestWebsocket_SuccessString",
-		Call: call.Message{
+		Call: call.Websocket{
 			Scheme: call.WebsocketSchemeWS,
 			URL:    fmt.Sprintf("localhost:%d", 8090),
 			Path:   "/handler-string",
@@ -309,7 +308,7 @@ func TestWebsocket_SuccessString(t *testing.T) {
 				"userId": 1
 			}`,
 		},
-		Message: expect.Message{
+		Receive: expect.Message{
 			Content: `
 			foo
 			 bar`,
@@ -324,7 +323,7 @@ func TestWebsocket_SuccessString(t *testing.T) {
 func TestWebsocket_InvalidURL(t *testing.T) {
 	err := Test(&WebsocketTestCase{
 		Description: "TestWebsocket_InvalidURL",
-		Call: call.Message{
+		Call: call.Websocket{
 			Scheme: call.WebsocketSchemeWS,
 			URL:    fmt.Sprintf("invalid:%d", 8090),
 			Path:   "/handler-json",
@@ -333,7 +332,7 @@ func TestWebsocket_InvalidURL(t *testing.T) {
 				"userId": 1
 			}`,
 		},
-		Message: expect.Message{
+		Receive: expect.Message{
 			Content: `{
 				"title": "some title",
 				"description": "<<PRESENCE>>",
@@ -362,7 +361,7 @@ func TestWebsocket_InvalidURL(t *testing.T) {
 func TestWebsocket_InvalidPath(t *testing.T) {
 	err := Test(&WebsocketTestCase{
 		Description: "TestWebsocket_InvalidPath",
-		Call: call.Message{
+		Call: call.Websocket{
 			Scheme: call.WebsocketSchemeWS,
 			URL:    fmt.Sprintf("localhost:%d", 8090),
 			Path:   "/invalid",
@@ -371,7 +370,7 @@ func TestWebsocket_InvalidPath(t *testing.T) {
 				"userId": 1
 			}`,
 		},
-		Message: expect.Message{
+		Receive: expect.Message{
 			Content: `{
 				"title": "some title",
 				"description": "<<PRESENCE>>",


### PR DESCRIPTION
You can now test websockets

```go
func TestWebsocket_SuccessJSON(t *testing.T) {
	err := Test(&WebsocketTestCase{
		Description: "TestWebsocket_SuccessJSON",
		Call: call.Websocket{
			Scheme: call.WebsocketSchemeWS,
			URL:    fmt.Sprintf("localhost:%d", 8090),
			Path:   "/handler-json",
			Message: `{
				"title": "some title",
				"userId": 1
			}`,
		},
		Receive: expect.Message{
			Content: `{
				"title": "some title",
				"description": "<<PRESENCE>>",
				"userId": 1,
				"comments": [
					{ "id": 1, "text": "foo" },
					{ "id": 2, "text": "bar" }
				]
			}`,
		},
		Assertions: []assertion.Assertion{
			&assertion.HTTP{
				Request: expect.Request{
					URL:    "https://jsonplaceholder.typicode.com/posts/1",
					Method: http.MethodGet,
				},
			},
		},
	})

	if err != nil {
		t.Fatal(err)
	}
}
```